### PR TITLE
fix: loading config file was flakey

### DIFF
--- a/cmd/stentor/integration_test.go
+++ b/cmd/stentor/integration_test.go
@@ -118,7 +118,6 @@ func runTest(name, relPath, wd string, run test.RunFunc) func(t *testing.T) {
 		}
 
 		if *test.UpdateGolden {
-			testCase.UpdateStderr(testEnv.GetStderr())
 			testCase.UpdateStdout(testEnv.GetStdout())
 		} else {
 			testCase.CompareError(err, testEnv.GetStderr())

--- a/cmd/stentor/stentor.go
+++ b/cmd/stentor/stentor.go
@@ -77,6 +77,12 @@ func (s *Stentor) Run() int {
 		return succesfulExitCode
 	}
 
+	// determine path to config file
+	if !filepath.IsAbs(s.configFile) {
+		s.configFile = filepath.Join(s.WorkDir, s.configFile)
+		s.configFile = filepath.Clean(s.configFile)
+	}
+
 	// parse config file
 	data, err := ioutil.ReadFile(s.configFile)
 	if err != nil {
@@ -102,7 +108,7 @@ func (s *Stentor) parseFlags() error {
 	flags := flag.NewFlagSet(appName, flag.ContinueOnError)
 	flags.SetOutput(s.err.Writer())
 
-	flags.StringVar(&s.configFile, "config", filepath.Join(".stentor.d/stentor.toml"), "path to config file")
+	flags.StringVar(&s.configFile, "config", filepath.Join(".stentor.d", "stentor.toml"), "path to config file")
 	flags.BoolVar(&s.showVersion, "version", false, "show version information")
 
 	// setup usage information

--- a/cmd/stentor/testdata/config/invalid/stderr.txt
+++ b/cmd/stentor/testdata/config/invalid/stderr.txt
@@ -1,1 +1,1 @@
-could not parse config file: (1, 6): was expecting token =, but got "is" instead
+could not parse config file: \(1, 6\): was expecting token =, but got "is" instead

--- a/cmd/stentor/testdata/config/missing/stderr.txt
+++ b/cmd/stentor/testdata/config/missing/stderr.txt
@@ -1,1 +1,1 @@
-could not read config files: open ./stentor.toml: no such file or directory
+could not read config files: open .*/stentor.toml: no such file or directory

--- a/magefile.go
+++ b/magefile.go
@@ -43,6 +43,11 @@ const (
 )
 
 var (
+	// Aliases for mage targets
+	Aliases = map[string]interface{}{
+		"tests": Test,
+	}
+
 	// Default mage target
 	Default = All
 


### PR DESCRIPTION

The way we were loading the config file caused the integration tests
to be flakey. This changes to process to check if the config path is an
absolute path, and if is not joins it to the exec's working directory.

To make the golden files work correctly, they are now parsed as a regex
and then matched against the captured stderr. This means we can't update
the stderr files, so that method is removed from the test harness.