### PR TITLE
fix(newsfile): scan for start comments

### DIFF
--- a/.stentor.d/28.fix.start-comment-scanning.md
+++ b/.stentor.d/28.fix.start-comment-scanning.md
@@ -1,0 +1,8 @@
+Fixed an issue where `stentor` could fail to find the start comment.
+
+The original way `stentor` scanned for the start comment
+worked so long as the newline after the comment
+didn't align just after the end of the internal read buffer.
+To fix that,
+stentor now scans the end of the read buffer
+looking for partial matches with the start comment.

--- a/newsfile/newsfile.go
+++ b/newsfile/newsfile.go
@@ -27,7 +27,7 @@ const (
 )
 
 func WriteFragments(fn, startComment string, data []byte, keepHeader bool) error {
-	tf, err := writeFragments(fn, startComment, data, keepHeader)
+	tf, err := writeFragments(fn, []byte(startComment), data, keepHeader)
 	if err != nil {
 		return err
 	}
@@ -41,7 +41,7 @@ func WriteFragments(fn, startComment string, data []byte, keepHeader bool) error
 	return nil
 }
 
-func writeFragments(fn, startComment string, data []byte, keepHeader bool) (string, error) {
+func writeFragments(fn string, startComment, data []byte, keepHeader bool) (string, error) {
 	dst, err := ioutil.TempFile("", "")
 	if err != nil {
 		return "", err
@@ -71,7 +71,7 @@ func writeFragments(fn, startComment string, data []byte, keepHeader bool) (stri
 }
 
 // nolint:gocognit // try to simplify this at some point
-func copyIntoFile(dst io.Writer, src io.Reader, startComment string, data []byte, keepHeader bool) error {
+func copyIntoFile(dst io.Writer, src io.Reader, startComment, data []byte, keepHeader bool) error {
 	var partialBuf []byte = make([]byte, 0)
 	var startFound bool
 	for {
@@ -83,7 +83,9 @@ func copyIntoFile(dst io.Writer, src io.Reader, startComment string, data []byte
 		}
 
 		// trim off zero bytes if we under read
-		readBuf = readBuf[:n]
+		if n < readLength {
+			readBuf = readBuf[:n]
+		}
 
 		if len(partialBuf) > 0 {
 			// we had a partial read so prepend it to readBuf
@@ -93,7 +95,7 @@ func copyIntoFile(dst io.Writer, src io.Reader, startComment string, data []byte
 
 		if !startFound {
 			// find index of startComment
-			idx := bytes.Index(readBuf, []byte(startComment))
+			idx := bytes.Index(readBuf, startComment)
 			if idx >= 0 {
 				idx += len(startComment)
 				if keepHeader {
@@ -105,10 +107,12 @@ func copyIntoFile(dst io.Writer, src io.Reader, startComment string, data []byte
 				}
 				startFound = true
 			} else {
-				// trim off everything after the last full line
-				lastIdx := bytes.LastIndex(readBuf, []byte("\n"))
-				if lastIdx >= 0 && lastIdx < len(readBuf)-1 {
-					readBuf, partialBuf = readBuf[:idx+1], readBuf[idx+1:]
+				// check for sub-strings of the start comment at the end of the read
+				for i := len(startComment) - 1; i >= 0 && len(readBuf)-i > 0; i-- {
+					if bytes.Equal(startComment[:i], readBuf[len(readBuf)-i:]) {
+						readBuf, partialBuf = readBuf[:len(readBuf)-i], readBuf[len(readBuf)-i:]
+						break
+					}
 				}
 			}
 		}

--- a/newsfile/newsfile_test.go
+++ b/newsfile/newsfile_test.go
@@ -16,6 +16,7 @@ package newsfile
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -41,60 +42,79 @@ func TestWriteFragments(t *testing.T) {
 	defer os.Chdir(wd) // nolint:errcheck // defer func
 
 	fn := filepath.Join(tmpdir, "file")
-	err = ioutil.WriteFile(fn, []byte("some text\n\n.. stentor output starts\n\nsome more text\n"), 0600)
-	must.NoError(err)
+	must.NoError(ioutil.WriteFile(fn, []byte("some text\n\n.. stentor output starts\n\nsome more text\n"), 0600))
 
-	if err := WriteFragments(fn, stentor.CommentRST, []byte("\nadded data"), true); is.NoError(err) {
+	if err := WriteFragments(fn, stentor.CommentRST, []byte("added data\n"), true); is.NoError(err) {
 		data, err := ioutil.ReadFile(fn)
 		must.NoError(err)
-		is.Equal("some text\n\n.. stentor output starts\n\nadded data\nsome more text\n", string(data))
+		is.Equal("some text\n\n.. stentor output starts\nadded data\n\nsome more text\n", string(data))
 	}
 }
 
+func TestWriteFragments_no_comment(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "stentor-")
+	require.NoError(t, err)
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	require.NoError(t, os.Chdir(tmpdir))
+	defer os.Chdir(wd) // nolint:errcheck // defer func
+
+	fn := filepath.Join(tmpdir, "file")
+	require.NoError(t, ioutil.WriteFile(fn, []byte("some text\nsome more text\n"), 0600))
+	require.EqualError(t, WriteFragments(fn, stentor.CommentMD, []byte("added data\n"), true), "no start comment found")
+}
+
 func Test_copyIntoFile(t *testing.T) {
-	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		nt := newsfileGen().Draw(t, "newsfile").(newsfileTest)
 
-	t.Run("comment exists", rapid.MakeCheck(func(t *rapid.T) {
-		startComment := rapid.SampledFrom([]string{
-			stentor.CommentMD,
-			stentor.CommentRST,
-		}).Draw(t, "startComment").(string)
+		var src io.Reader
+		if nt.includeComment {
+			src = bytes.NewBufferString(nt.header + nt.startComment + nt.trailer)
+		} else {
+			src = bytes.NewBufferString(nt.header + nt.trailer)
+		}
 
-		// we pick these sizes to force the start comment out past a single read
-		header := rapid.StringN(512, 1024, -1).Draw(t, "header").(string)
-		trailer := rapid.StringN(512, 1024, -1).Draw(t, "trailer").(string)
-		keepHeader := rapid.Bool().Draw(t, "keepHeader").(bool)
-
-		srcString := header + startComment + trailer
-		data := rapid.String().Draw(t, "data").(string)
-
-		src := bytes.NewBufferString(srcString)
 		dst := &bytes.Buffer{}
+		err := copyIntoFile(dst, src, []byte(nt.startComment), []byte(nt.data), nt.keepHeader)
+		if nt.includeComment {
+			if err != nil {
+				t.Fatalf("copyIntoFile() returned an error: %v", err)
+			}
 
-		err := copyIntoFile(dst, src, startComment, []byte(data), keepHeader)
-		if err != nil {
-			t.Fatalf("copyIntoFile() returned an error: %v", err)
+			want := nt.data + nt.trailer
+			if nt.keepHeader {
+				want = nt.header + nt.startComment + want
+			}
+			if got := dst.String(); got != want {
+				t.Errorf("copyIntoFile() wrote\n%s\n\nwant\n%s", got, want)
+			}
+		} else if err == nil || err.Error() != "no start comment found" {
+			t.Fatalf("copyIntoFile() returned an error, %v, wanted, %q", err, "no start comment found")
 		}
+	})
+}
 
-		want := data + trailer
-		if keepHeader {
-			want = header + startComment + want
+type newsfileTest struct {
+	startComment, header, trailer, data string
+	keepHeader, includeComment          bool
+}
+
+func newsfileGen() *rapid.Generator {
+	return rapid.Custom(func(t *rapid.T) newsfileTest {
+		return newsfileTest{
+			startComment: rapid.SampledFrom([]string{
+				stentor.CommentMD,
+				stentor.CommentRST,
+			}).Draw(t, "startComment").(string),
+			// we pick these sizes to force the start comment out past a single read
+			header:         rapid.StringN(512, 1024, -1).Draw(t, "header").(string),
+			trailer:        rapid.StringN(512, 1024, -1).Draw(t, "trailer").(string),
+			data:           rapid.String().Draw(t, "data").(string),
+			keepHeader:     rapid.Bool().Draw(t, "keepHeader").(bool),
+			includeComment: rapid.Bool().Draw(t, "includeComment").(bool),
 		}
-		if got := dst.String(); got != want {
-			t.Errorf("copyIntoFile() wrote\n%s\n\nwant\n%s", got, want)
-		}
-	}))
-
-	t.Run("no comment exists", rapid.MakeCheck(func(t *rapid.T) {
-		startComment := rapid.SampledFrom([]string{stentor.CommentMD, stentor.CommentRST}).
-			Draw(t, "startComment").(string)
-		header := rapid.StringN(512, 1024, -1).Draw(t, "header").(string)
-		trailer := rapid.StringN(512, 1024, -1).Draw(t, "trailer").(string)
-		src := bytes.NewBufferString(header + trailer)
-		dst := &bytes.Buffer{}
-		data := rapid.String().Draw(t, "data").(string)
-
-		err := copyIntoFile(dst, src, startComment, []byte(data), true)
-		assert.EqualError(t, err, "no start comment found")
-	}))
+	})
 }

--- a/stentor.go
+++ b/stentor.go
@@ -27,6 +27,6 @@ const (
 )
 
 const (
-	CommentMD  = "<!-- stentor output starts -->\n"
+	CommentMD  = "<!-- stentor output starts -->"
 	CommentRST = ".. stentor output starts\n"
 )


### PR DESCRIPTION
The original way `stentor` scanned for the start comment worked so long
as the newline after the comment didn't align just after the end of the
internal read buffer. To fix that, stentor now scans the end of the read
buffer looking for partial matches with the start comment.

Fixes #28

(cherry picked from commit 327edd04efeac3e1a169a78494ae4f1b7247463a)