### PR TITLE
ci: fix tag workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,5 +1,5 @@
 ---
-name: Lint
+name: actionlint
 
 on:
   push:
@@ -8,14 +8,11 @@ on:
 
 jobs:
   lint:
-    name: Run linters
+    name: Run actionlint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
-
-      - name: Lint with golangci-lint
-        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 # v2.5.2
 
       - name: Lint with actionlint
         uses: reviewdog/action-actionlint@890a514e7f1577c0e0fe7790b4cb8be4a1fc47d6 # v1.14.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,28 @@ jobs:
           go-version: ${{ matrix.go_version }}
         id: go
 
+      - name: Determine cache locations
+        id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
       - name: Check out code
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
         with:
           fetch-depth: 0
+
+      - name: Go Build Cache
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ matrix.os }}-go-${{ matrix.go_version }}-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Module Cache
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ matrix.os }}-go-${{ matrix.go_version }}-mod-${{ hashFiles('**/go.sum') }}
 
       - name: Get dependencies
         run: go mod download

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,18 @@
+---
+name: golangci-lint
+
+on:
+  push:
+    branches: [main, release-*]
+  pull_request:
+
+jobs:
+  lint:
+    name: Run golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+
+      - name: Lint with golangci-lint
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 # v2.5.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,11 +11,11 @@ jobs:
     name: Run linters
     runs-on: ubuntu-latest
     steps:
-      - name: Setup python
-        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # v2.2.2
-
       - name: Checkout code
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
-      - name: Run pre-commit hooks
-        uses: pre-commit/action@9b88afc9cd57fd75b655d5c71bd38146d07135fe # v2.0.3
+      - name: Lint with golangci-lint
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 # v2.5.2
+
+      - name: Lint with actionlint
+        uses: reviewdog/action-actionlint@890a514e7f1577c0e0fe7790b4cb8be4a1fc47d6 # v1.14.0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tag:
     name: Tag release commit
-    if: 'startsWith(github.event.commits[0].message, "release: ")'
+    if: "startsWith(github.event.commits[0].message, 'release: ')"
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,11 @@ repos:
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
 
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.6.4
+    hooks:
+      - id: actionlint
+
   - repo: https://github.com/golangci/golangci-lint
     rev: v1.42.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,8 @@ repos:
     hooks:
       - id: golangci-lint
         args: [--allow-parallel-runners]
+
+ci:
+  autofix_prs: false
+  autoupdate_commit_msg: 'chore: auto-update of pre-commit hooks'
+  skip: [actionlint, golangci-lint]

--- a/cmd/stentor/integration_test.go
+++ b/cmd/stentor/integration_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 // Copyright © 2020 The Stentor Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +14,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-// +build !windows
 
 package main
 


### PR DESCRIPTION
This also adds `actionlint` to the pre-commit hooks, to hopefully catch
these kinds of errors before they are merged.