### PR TITLE
ci: configure dependabot grouped PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,17 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      gomod:
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ issues:
 linters:
   disable-all: true
   enable:
-    - depguard
     - errcheck
     - gocognit
     - gocritic


### PR DESCRIPTION
This should reduce the number of PRs and churn to update dependencies.