### PR TITLE
feat: throw error on unknown section name

### DIFF
--- a/.stentor.d/266.feat.error-on-unknown-section-name.md
+++ b/.stentor.d/266.feat.error-on-unknown-section-name.md
@@ -1,0 +1,2 @@
+Stentor now throws an error when it parses a fragment with a section name
+that does not exist in its list of configured sections.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,7 @@
 # Credits
 
-In alphabetial order:
+In alphabetical order:
 
+- Grant Buskey <grantbuskey@gmail.com>
 - Mihai Ibanescu <Mihai.Ibanescu@sas.com>
 - Walter Scheper <walter.scheper@gmail.com>

--- a/cmd/stentor/stentor_test.go
+++ b/cmd/stentor/stentor_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/wfscheper/stentor/config"
+	"github.com/wfscheper/stentor/fragment"
 )
 
 func TestStentor_displayVersion(t *testing.T) {
@@ -16,4 +18,101 @@ func TestStentor_displayVersion(t *testing.T) {
 	s.displayVersion()
 
 	assert.Equal(t, "stentor dev built from unknown on unknown\n", out.String())
+}
+
+func TestStentor_verifyFragmentSections(t *testing.T) {
+	tests := []struct {
+		name      string
+		sections  []config.Section
+		fragments []fragment.Fragment
+		want      string
+	}{
+		{
+			name: "valid",
+			sections: []config.Section{
+				{
+					Name:      "Added",
+					ShortName: "add",
+				},
+				{
+					Name:      "Removed",
+					ShortName: "remove",
+				},
+			},
+			fragments: []fragment.Fragment{
+				{
+					Section: "add",
+				},
+				{
+					Section: "remove",
+				},
+			},
+		},
+		{
+			name: "invalid",
+			want: "fragment files contained the following invalid section names: " +
+				"[invalid]. section names must be one of the following: [add remove]",
+			sections: []config.Section{
+				{
+					Name:      "Added",
+					ShortName: "add",
+				},
+				{
+					Name:      "Removed",
+					ShortName: "remove",
+				},
+			},
+			fragments: []fragment.Fragment{
+				{
+					Section: "add",
+				},
+				{
+					Section: "remove",
+				},
+				{
+					Section: "invalid",
+				},
+			},
+		},
+		{
+			name: "no valid sections",
+			want: "fragment files contained the following invalid section names: " +
+				"[add remove]. section names must be one of the following: []",
+			sections: []config.Section{},
+			fragments: []fragment.Fragment{
+				{
+					Section: "add",
+				},
+				{
+					Section: "remove",
+				},
+			},
+		},
+		{
+			name: "no fragments",
+			want: "",
+			sections: []config.Section{
+				{
+					Name:      "Added",
+					ShortName: "add",
+				},
+				{
+					Name:      "Removed",
+					ShortName: "remove",
+				},
+			},
+			fragments: []fragment.Fragment{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := verifyFragmentSections(tt.sections, tt.fragments)
+			if tt.want == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Stentor now throws an error when it parses a section name
that does not exist in its list of sections Fixes #259