### PR TITLE
docs: add initial release example

### DIFF
--- a/.stentor.d/299.change.initial-release.md
+++ b/.stentor.d/299.change.initial-release.md
@@ -1,0 +1,1 @@
+Updated documentation on how to do initial release.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ go install github.com/wfscheper/stentor/cmd/stentor@latest
 
 ### Setup
 
-This example assumes that there is already a v0.1.0 tag.
-
 1. Create a `.stentor.d` directory in your git repository.
 
    ```bash
@@ -75,6 +73,113 @@ This example assumes that there is already a v0.1.0 tag.
    `fooer` no longer chokes when parsing a foo with the special characters `!@#$%`.
    EOF
    ```
+
+1. *(Optional)* Create initial `CHANGELOG.md`.
+   This is optional,
+   but lets you write an intro section.
+
+   ```bash
+   $ cat >CHANGELOG.md << EOF
+   # Changelog
+
+   All notable changes to this project will be documented in this file.
+
+   The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+   and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+   Changes for the next release can be found in the [".stentor.d" directory](./.stentor.d).
+
+   <!-- stentor output starts -->
+   EOF
+   ```
+
+1. Commit the changes.
+
+### First release
+
+This assumes that you are making a first release,
+ie. there is no "previous" version.
+
+1. Run `git log`,
+   go to the start of your commit history,
+   and record the first commit hash.
+
+1. Run `stentor` to see the output it would add to the CHANGELOG.md file.
+
+   ```bash
+   $ stentor v0.1.0 2e808ef3f3a64e8c5965bcc130d4006d6abb56a1
+   ## [v0.1.0] - 2006-01-02
+
+   ### Features
+
+   - Added the foo feature
+
+     The foo feature is full of foos, and is awesome.
+     [#1](https://github.com/myname/myrepo/issues/1)
+
+
+   ### Bug fixes
+
+   - Fixed parsing foos that contain special characters
+
+     `fooer` no longer chokes when parsing a foo with the special characters `!@#$%`.
+     [#2](https://github.com/myname/myrepo/issues/2)
+
+   [v0.1.0]: https://github.com/myname/myrepo/compare/2e808ef3f3a64e8c5965bcc130d4006d6abb56a1...v0.1.0
+
+   ---
+
+   ```
+
+### General release
+
+1. . Run `stentor` to see the output it would add to the CHANGELOG.md file.
+
+   ```bash
+   $ stentor v0.2.0 v0.1.0
+   ## [v0.2.0] - 2006-01-02
+
+   ### Features
+
+   - Added the foo feature
+
+     The foo feature is full of foos, and is awesome.
+     [#1](https://github.com/myname/myrepo/issues/1)
+
+
+   ### Bug fixes
+
+   - Fixed parsing foos that contain special characters
+
+     `fooer` no longer chokes when parsing a foo with the special characters `!@#$%`.
+     [#2](https://github.com/myname/myrepo/issues/2)
+
+   [v0.2.0]: https://github.com/myname/myrepo/compare/v0.1.0...v0.2.0
+
+   ---
+
+   ```
+
+1. Use the `-release` flag to consume the fragments
+   and update the news file.
+
+   **Note:** If a CHANGELOG.md does not exist already, one will be created.
+
+   ```bash
+   $ stentor -release v0.2.0 v0.1.0
+   $ git status
+   On branch master
+   Changes not staged for commit:
+     (use "git add <file>..." to update what will be committed)
+     (use "git restore <file>..." to discard changes in working directory)
+          modified:   CHANGELOG.md
+          deleted:    .stentor.d/1.feature.md
+          deleted:    .stentor.d/2.fix.md
+
+   no changes added to commit (use "git add" and/or "git commit -a")
+   ```
+
+### Subsequent releases
 
 1. Run stentor to see the output it would add to CHANGELOG.md.
 


### PR DESCRIPTION
This provides one way to do the first release of a project.

Closes #299